### PR TITLE
#129 add delete speciality endpoint for institution of education admin/moderator

### DIFF
--- a/YIF.Core.Data/Entities/SpecialtyToInstitutionOfEducation.cs
+++ b/YIF.Core.Data/Entities/SpecialtyToInstitutionOfEducation.cs
@@ -7,6 +7,7 @@ namespace YIF.Core.Data.Entities
         public string SpecialtyId { get; set; }
         public string InstitutionOfEducationId { get; set; }
         public string SpecialtyToIoEDescriptionId { get; set; }
+        public bool IsDeleted { get; set; }
 
         [ForeignKey("SpecialtyToIoEDescriptionId")]
         public virtual SpecialtyToIoEDescription SpecialtyToIoEDescription { get; set; }

--- a/YIF.Core.Data/Migrations/20210330085740_AddIsDeletedToSpecialtyToInstitutionOfEducation.Designer.cs
+++ b/YIF.Core.Data/Migrations/20210330085740_AddIsDeletedToSpecialtyToInstitutionOfEducation.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using YIF.Core.Data;
 
 namespace YIF.Core.Data.Migrations
 {
     [DbContext(typeof(EFDbContext))]
-    partial class EFDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210330085740_AddIsDeletedToSpecialtyToInstitutionOfEducation")]
+    partial class AddIsDeletedToSpecialtyToInstitutionOfEducation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/YIF.Core.Data/Migrations/20210330085740_AddIsDeletedToSpecialtyToInstitutionOfEducation.cs
+++ b/YIF.Core.Data/Migrations/20210330085740_AddIsDeletedToSpecialtyToInstitutionOfEducation.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace YIF.Core.Data.Migrations
+{
+    public partial class AddIsDeletedToSpecialtyToInstitutionOfEducation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "SpecialtyToInstitutionOfEducations",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "SpecialtyToInstitutionOfEducations");
+        }
+    }
+}

--- a/YIF.Core.Data/Seaders/SeederDB.cs
+++ b/YIF.Core.Data/Seaders/SeederDB.cs
@@ -897,11 +897,11 @@ namespace YIF.Core.Data.Seaders
                 specialitiesToInstitutionOfEducations.AddRange(new List<SpecialtyToInstitutionOfEducation>
                 {
                     #region Соціальні та поведінкові науки
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Соціологія").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Політологія").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Соціологія").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Політологія").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion
                     #region Математика та статистика
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId }
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false }
                     #endregion
                 });
                 #endregion
@@ -918,16 +918,16 @@ namespace YIF.Core.Data.Seaders
                 specialitiesToInstitutionOfEducations.AddRange(new List<SpecialtyToInstitutionOfEducation>
                 {
                     #region Інформаційні технології
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Системний аналіз").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інженерія програмного забезпечення").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Кібербезпека").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Системний аналіз").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інженерія програмного забезпечення").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Кібербезпека").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion
                     #region Математика та статистика
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Прикладна математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Прикладна математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion
                     #region Електрична інженерія
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Гідроенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId }
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Гідроенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false }
                     #endregion
                 });
                 #endregion
@@ -944,16 +944,16 @@ namespace YIF.Core.Data.Seaders
                 specialitiesToInstitutionOfEducations.AddRange(new List<SpecialtyToInstitutionOfEducation>
                 {
                     #region Інформаційні технології
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Системний аналіз").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інженерія програмного забезпечення").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Системний аналіз").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інженерія програмного забезпечення").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion
                     #region Автоматизація та приладобудування
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Метрологія та інформаційно-вимірювальна техніка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Автоматизація та комп’ютерно-інтегровані технології").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Метрологія та інформаційно-вимірювальна техніка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Автоматизація та комп’ютерно-інтегровані технології").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion
                     #region Електрична інженерія
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Гідроенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Енергетичне машинобудування").Id,InstitutionOfEducationId = currentInstitutionOfEducationId }
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Гідроенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Енергетичне машинобудування").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false }
                     #endregion
                 });
                 #endregion
@@ -968,8 +968,8 @@ namespace YIF.Core.Data.Seaders
                 specialitiesToInstitutionOfEducations.AddRange(new List<SpecialtyToInstitutionOfEducation>
                 {
                     #region Математика та статистика
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion                 
                 });
                 #endregion
@@ -987,26 +987,26 @@ namespace YIF.Core.Data.Seaders
                 specialitiesToInstitutionOfEducations.AddRange(new List<SpecialtyToInstitutionOfEducation>
                 {
                     #region Електрична інженерія
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Атомна енергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Теплоенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Електроенергетика, електротехніка та електромеханіка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Атомна енергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Теплоенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Електроенергетика, електротехніка та електромеханіка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion  
                     #region Математика та статистика
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Прикладна математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Прикладна математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion 
                     #region Інформаційні технології
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інженерія програмного забезпечення").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інформаційні системи та технології").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Кібербезпека").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Комп’ютерна інженерія").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Комп'ютерні науки").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Системний аналіз").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інженерія програмного забезпечення").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Інформаційні системи та технології").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Кібербезпека").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Комп’ютерна інженерія").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Комп'ютерні науки").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Системний аналіз").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion 
                     #region Автоматизація та приладобудування
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Метрологія та інформаційно-вимірювальна техніка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Мікро- та наносистемна техніка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Метрологія та інформаційно-вимірювальна техніка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Мікро- та наносистемна техніка").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion 
 
                 });
@@ -1023,13 +1023,13 @@ namespace YIF.Core.Data.Seaders
                 specialitiesToInstitutionOfEducations.AddRange(new List<SpecialtyToInstitutionOfEducation>
                 {
                     #region Електрична інженерія
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Атомна енергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Теплоенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Атомна енергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Теплоенергетика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion  
                     #region Математика та статистика
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Прикладна математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
-                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Прикладна математика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
+                    new SpecialtyToInstitutionOfEducation { SpecialtyId = specialities.FirstOrDefault(x => x.Name == "Статистика").Id,InstitutionOfEducationId = currentInstitutionOfEducationId, IsDeleted = false },
                     #endregion                   
                 });
                 #endregion

--- a/YIF.Core.Domain/DtoModels/EntityDTO/SpecialityToInstitutionOfEducationDTO.cs
+++ b/YIF.Core.Domain/DtoModels/EntityDTO/SpecialityToInstitutionOfEducationDTO.cs
@@ -6,6 +6,7 @@
         public string SpecialityId { get; set; }
         public string InstitutionOfEducationId { get; set; }
         public string SpecialtyToIoEDescriptionId { get; set; }
+        public bool IsDeleted { get; set; }
 
         public virtual SpecialtyDTO Speciality { get; set; }
         public virtual InstitutionOfEducationDTO InstitutionOfEducation { get; set; }

--- a/YIF.Core.Domain/DtoModels/EntityDTO/SpecialtyToInstitutionOfEducationDTO.cs
+++ b/YIF.Core.Domain/DtoModels/EntityDTO/SpecialtyToInstitutionOfEducationDTO.cs
@@ -6,6 +6,7 @@
         public string SpecialtyId { get; set; }
         public string InstitutionOfEducationId { get; set; }
         public string SpecialtyToIoEDescriptionId { get; set; }
+        public bool IsDeleted { get; set; }
 
         public virtual SpecialtyToIoEDescriptionDTO SpecialtyToIoEDescription { get; set; }
         public virtual SpecialtyDTO Specialty { get; set; }

--- a/YIF.Core.Domain/ServiceInterfaces/IIoEAdminService.cs
+++ b/YIF.Core.Domain/ServiceInterfaces/IIoEAdminService.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.ApiModels.ResponseApiModels;
+
+namespace YIF.Core.Domain.ServiceInterfaces
+{
+    public interface IIoEAdminService
+    {
+        Task<ResponseApiModel<DescriptionResponseApiModel>> AddSpecialtyToIoe(SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE);
+        Task DeleteSpecialtyToIoe(SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE);
+    }
+}

--- a/YIF.Core.Domain/ServiceInterfaces/IIoEModeratorService.cs
+++ b/YIF.Core.Domain/ServiceInterfaces/IIoEModeratorService.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.ApiModels.ResponseApiModels;
+
+namespace YIF.Core.Domain.ServiceInterfaces
+{
+    public interface IIoEModeratorService
+    {
+        Task<ResponseApiModel<DescriptionResponseApiModel>> AddSpecialtyToIoe(SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE);
+        Task DeleteSpecialtyToIoe(SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE);
+    }
+}

--- a/YIF.Core.Domain/ServiceInterfaces/ISpecialtyService.cs
+++ b/YIF.Core.Domain/ServiceInterfaces/ISpecialtyService.cs
@@ -17,5 +17,6 @@ namespace YIF.Core.Domain.ServiceInterfaces
         Task DeleteSpecialtyAndInstitutionOfEducationFromFavorite(string specialtyId, string institutionOfEducationId, string userId);
         Task AddSpecialtyToFavorite(string specialtyId, string userId);
         Task DeleteSpecialtyFromFavorite(string specialtyId, string userId);
+        Task DeleteSpecialtyFromInstitutionOfEducation(string specialtyId, string institutionOfEducationId);
     }
 }

--- a/YIF.Core.Service/Concrete/Services/IoEAdminService.cs
+++ b/YIF.Core.Service/Concrete/Services/IoEAdminService.cs
@@ -1,0 +1,79 @@
+﻿using System.Resources;
+using System.Threading.Tasks;
+using SendGrid.Helpers.Errors.Model;
+using YIF.Core.Data.Entities;
+using YIF.Core.Data.Interfaces;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.ApiModels.ResponseApiModels;
+using YIF.Core.Domain.DtoModels.EntityDTO;
+using YIF.Core.Domain.ServiceInterfaces;
+
+namespace YIF.Core.Service.Concrete.Services
+{
+    public class IoEAdminService:IIoEAdminService
+    {
+        private readonly ISpecialtyRepository<Specialty, SpecialtyDTO> _specialtyRepository;
+        private readonly IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO> _ioERepository;
+        private readonly ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO> _specialtyToIoERepository;
+        private readonly ResourceManager _resourceManager;
+
+        public IoEAdminService(
+            ISpecialtyRepository<Specialty, SpecialtyDTO> specialtyRepository, 
+            IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO> ioERepository,
+            ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO> specialtyToIoERepository,
+            ResourceManager resourceManager)
+        {
+            _specialtyRepository = specialtyRepository;
+            _ioERepository = ioERepository;
+            _specialtyToIoERepository = specialtyToIoERepository;
+            _resourceManager = resourceManager;
+
+        }
+
+        public async Task<ResponseApiModel<DescriptionResponseApiModel>> AddSpecialtyToIoe(
+            SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE)
+        {
+            var result = new ResponseApiModel<DescriptionResponseApiModel>();
+
+            var specialty = await _specialtyRepository.ContainsById(specialtyToIoE.SpecialtyId);
+            var institutionOfEducation = await _ioERepository.ContainsById(specialtyToIoE.InstitutionOfEducationId);
+            var entity = new SpecialtyToInstitutionOfEducation()
+            {
+                SpecialtyId = specialtyToIoE.SpecialtyId,
+                InstitutionOfEducationId = specialtyToIoE.InstitutionOfEducationId
+            };
+
+            if (institutionOfEducation == false)
+                throw new BadRequestException(_resourceManager.GetString("InstitutionOfEducationNotFound"));
+
+            if (specialty == false)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyNotFound"));
+
+            await _specialtyToIoERepository.AddSpecialty(entity);
+            return result.Set(new DescriptionResponseApiModel("Specialty was successfully added to the Institution of Education"), true);
+        }
+
+        public async Task DeleteSpecialtyToIoe(SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE)
+        {
+            var specialty = await _specialtyRepository.ContainsById(specialtyToIoE.SpecialtyId);
+            var institutionOfEducation = await _ioERepository.ContainsById(specialtyToIoE.InstitutionOfEducationId);
+            var entity = await _specialtyToIoERepository.Find(s => s.SpecialtyId == specialtyToIoE.SpecialtyId && s.InstitutionOfEducationId == specialtyToIoE.InstitutionOfEducationId);
+
+            if (institutionOfEducation == false)
+                throw new BadRequestException(_resourceManager.GetString("InstitutionOfEducationNotFound"));
+
+            if (specialty == false)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyNotFound"));
+
+            if (entity == null)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyInInstitutionOfEducationNotFound"));
+
+            await _specialtyToIoERepository.Update(new SpecialtyToInstitutionOfEducation
+            {
+                SpecialtyId = specialtyToIoE.SpecialtyId,
+                InstitutionOfEducationId = specialtyToIoE.InstitutionOfEducationId,
+                IsDeleted = true
+            }); ;
+        }
+    }
+}

--- a/YIF.Core.Service/Concrete/Services/IoEModeratorService.cs
+++ b/YIF.Core.Service/Concrete/Services/IoEModeratorService.cs
@@ -1,0 +1,79 @@
+﻿using System.Resources;
+using System.Threading.Tasks;
+using SendGrid.Helpers.Errors.Model;
+using YIF.Core.Data.Entities;
+using YIF.Core.Data.Interfaces;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.ApiModels.ResponseApiModels;
+using YIF.Core.Domain.DtoModels.EntityDTO;
+using YIF.Core.Domain.ServiceInterfaces;
+
+namespace YIF.Core.Service.Concrete.Services
+{
+    public class IoEModeratorService:IIoEModeratorService
+    {
+        private readonly ISpecialtyRepository<Specialty, SpecialtyDTO> _specialtyRepository;
+        private readonly IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO> _ioERepository;
+        private readonly ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO> _specialtyToIoERepository;
+        private readonly ResourceManager _resourceManager;
+
+        public IoEModeratorService(
+            ISpecialtyRepository<Specialty, SpecialtyDTO> specialtyRepository,
+            IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO> ioERepository,
+            ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO> specialtyToIoERepository,
+            ResourceManager resourceManager)
+        {
+            _specialtyRepository = specialtyRepository;
+            _ioERepository = ioERepository;
+            _specialtyToIoERepository = specialtyToIoERepository;
+            _resourceManager = resourceManager;
+
+        }
+
+        public async Task<ResponseApiModel<DescriptionResponseApiModel>> AddSpecialtyToIoe(
+            SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE)
+        {
+            var result = new ResponseApiModel<DescriptionResponseApiModel>();
+
+            var specialty = await _specialtyRepository.ContainsById(specialtyToIoE.SpecialtyId);
+            var institutionOfEducation = await _ioERepository.ContainsById(specialtyToIoE.InstitutionOfEducationId);
+            var entity = new SpecialtyToInstitutionOfEducation()
+            {
+                SpecialtyId = specialtyToIoE.SpecialtyId,
+                InstitutionOfEducationId = specialtyToIoE.InstitutionOfEducationId
+            };
+
+            if (institutionOfEducation == false)
+                throw new BadRequestException(_resourceManager.GetString("InstitutionOfEducationNotFound"));
+
+            if (specialty == false)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyNotFound"));
+
+            await _specialtyToIoERepository.AddSpecialty(entity);
+            return result.Set(new DescriptionResponseApiModel("Specialty was successfully added to the Institution of Education"), true);
+        }
+
+        public async Task DeleteSpecialtyToIoe(SpecialtyToInstitutionOfEducationPostApiModel specialtyToIoE)
+        {
+            var specialty = await _specialtyRepository.ContainsById(specialtyToIoE.SpecialtyId);
+            var institutionOfEducation = await _ioERepository.ContainsById(specialtyToIoE.InstitutionOfEducationId);
+            var entity = await _specialtyToIoERepository.Find(s => s.SpecialtyId == specialtyToIoE.SpecialtyId && s.InstitutionOfEducationId == specialtyToIoE.InstitutionOfEducationId);
+
+            if (institutionOfEducation == false)
+                throw new BadRequestException(_resourceManager.GetString("InstitutionOfEducationNotFound"));
+
+            if (specialty == false)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyNotFound"));
+
+            if (entity == null)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyInInstitutionOfEducationNotFound"));
+
+            await _specialtyToIoERepository.Update(new SpecialtyToInstitutionOfEducation
+            {
+                SpecialtyId = specialtyToIoE.SpecialtyId,
+                InstitutionOfEducationId = specialtyToIoE.InstitutionOfEducationId,
+                IsDeleted = true
+            }); ;
+        }
+    }
+}

--- a/YIF.Core.Service/Concrete/Services/SpecialtyService.cs
+++ b/YIF.Core.Service/Concrete/Services/SpecialtyService.cs
@@ -255,5 +255,28 @@ namespace YIF.Core.Service.Concrete.Services
                 GraduateId = graduate.Id
             });
         }
+
+        public async Task DeleteSpecialtyFromInstitutionOfEducation(string specialtyId, string institutionOfEducationId)
+        {
+            var specialty = await _specialtyRepository.Get(specialtyId);
+            var institutionOfEducation = await _institutionOfEducationRepository.Get(institutionOfEducationId);
+            var specialtyToIoE = await _specialtyToInstitutionOfEducationRepository.Find(s => s.SpecialtyId == specialtyId && s.InstitutionOfEducationId == institutionOfEducationId);
+
+            if (institutionOfEducation == null)
+                throw new BadRequestException(_resourceManager.GetString("InstitutionOfEducationNotFound"));
+
+            if (specialty == null)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyNotFound"));
+
+            if (specialtyToIoE == null)
+                throw new BadRequestException(_resourceManager.GetString("SpecialtyInInstitutionOfEducationNotFound"));
+
+            await _specialtyToInstitutionOfEducationRepository.Update(new SpecialtyToInstitutionOfEducation
+            {
+                SpecialtyId = specialty.Id,
+                InstitutionOfEducationId = institutionOfEducation.Id,
+                IsDeleted = true
+            }); ;
+        }
     }
 }

--- a/YIF_Backend/Controllers/InstitutionOfEducationAdminController.cs
+++ b/YIF_Backend/Controllers/InstitutionOfEducationAdminController.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Resources;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.ApiModels.ResponseApiModels;
+using YIF.Core.Domain.ServiceInterfaces;
+
+namespace YIF_Backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [Produces("application/json")]
+    [Authorize(Roles = "InstitutionOfEducationAdmin")]
+    public class InstitutionOfEducationAdminController : ControllerBase
+    {
+        private readonly IIoEAdminService _ioEAdminService;
+        private readonly ResourceManager _resourceManager;
+
+        public InstitutionOfEducationAdminController(
+            IIoEAdminService ioEAdminService, 
+            ResourceManager resourceManager)
+        {
+            _ioEAdminService = ioEAdminService;
+            _resourceManager = resourceManager;
+        }
+
+        /// <summary>
+        /// Adds Specialty to the Institution of Education.
+        /// </summary>
+        /// <response code="200">Specialty successfully added to the Institution of Education</response>
+        /// <response code="400">If model state is not valid</response>
+        /// <response code="404">If specialty not found</response>
+        [ProducesResponseType(typeof(AuthenticateResponseApiModel), 200)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 400)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 404)]
+        [ProducesResponseType(typeof(ErrorDetails), 500)]
+        [HttpPost("AddSpecialtyToInstitutionOfEducation")]
+        public async Task<IActionResult> AddSpecialtyToIoE([FromBody] SpecialtyToInstitutionOfEducationPostApiModel model)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(new DescriptionResponseApiModel(_resourceManager.GetString("ModelIsInvalid")));
+            var result = await _ioEAdminService.AddSpecialtyToIoe(model);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Temporary delete specialty from institution of education.
+        /// </summary>
+        /// <returns>None</returns>
+        /// <response code="204">Returns if the specialty has been successfully deleted from institution of education.</response>
+        /// <response code="400">If id is not valid.</response>
+        /// <response code="401">If user is unauthorized, token is bad/expired</response>
+        /// <response code="403">If user is not institution of education admin or moderator.</response>
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 401)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 403)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 404)]
+        [ProducesResponseType(typeof(ErrorDetails), 500)]
+        [HttpPatch("DeleteSpecialtyFromInstitutionOfEducation")]
+        public async Task<IActionResult> DeleteSpecialtyFromIoE([FromBody] SpecialtyToInstitutionOfEducationPostApiModel model)
+        {
+            await _ioEAdminService.DeleteSpecialtyToIoe(model);
+            return NoContent();
+        }
+    }
+}

--- a/YIF_Backend/Controllers/InstitutionOfEducationModeratorController.cs
+++ b/YIF_Backend/Controllers/InstitutionOfEducationModeratorController.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Resources;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.ApiModels.ResponseApiModels;
+using YIF.Core.Domain.ServiceInterfaces;
+
+namespace YIF_Backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [Produces("application/json")]
+    [Authorize(Roles = "InstitutionOfEducationModerator")]
+    public class InstitutionOfEducationModeratorController : Controller
+    {
+        private readonly IIoEModeratorService _ioEModeratorService;
+        private readonly ResourceManager _resourceManager;
+
+        public InstitutionOfEducationModeratorController(
+            IIoEModeratorService ioEModeratorService,
+            ResourceManager resourceManager)
+        {
+            _ioEModeratorService = ioEModeratorService;
+            _resourceManager = resourceManager;
+        }
+
+        /// <summary>
+        /// Adds Specialty to the Institution of Education.
+        /// </summary>
+        /// <response code="200">Specialty successfully added to the Institution of Education</response>
+        /// <response code="400">If model state is not valid</response>
+        /// <response code="404">If specialty not found</response>
+        [ProducesResponseType(typeof(AuthenticateResponseApiModel), 200)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 400)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 404)]
+        [ProducesResponseType(typeof(ErrorDetails), 500)]
+        [HttpPost("AddSpecialtyToInstitutionOfEducation")]
+        public async Task<IActionResult> AddSpecialtyToIoE([FromBody] SpecialtyToInstitutionOfEducationPostApiModel model)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(new DescriptionResponseApiModel(_resourceManager.GetString("ModelIsInvalid")));
+            var result = await _ioEModeratorService.AddSpecialtyToIoe(model);
+            return Ok();
+        }
+
+        /// <summary>
+        /// Temporary delete specialty from institution of education.
+        /// </summary>
+        /// <returns>None</returns>
+        /// <response code="204">Returns if the specialty has been successfully deleted from institution of education.</response>
+        /// <response code="400">If id is not valid.</response>
+        /// <response code="401">If user is unauthorized, token is bad/expired</response>
+        /// <response code="403">If user is not institution of education admin or moderator.</response>
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 401)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 403)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 404)]
+        [ProducesResponseType(typeof(ErrorDetails), 500)]
+        [HttpPatch("DeleteSpecialtyFromInstitutionOfEducation")]
+        public async Task<IActionResult> DeleteSpecialtyFromIoE([FromBody] SpecialtyToInstitutionOfEducationPostApiModel model)
+        {
+            await _ioEModeratorService.DeleteSpecialtyToIoe(model);
+            return NoContent();
+        }
+    }
+}

--- a/YIF_Backend/Controllers/SpecialtyController.cs
+++ b/YIF_Backend/Controllers/SpecialtyController.cs
@@ -199,5 +199,25 @@ namespace YIF_Backend.Controllers
             await _specialtyService.DeleteSpecialtyFromFavorite(specialtyId, userId);
             return NoContent();
         }
+
+        /// <summary>
+        /// Temporary delete specialty from institution of education.
+        /// </summary>
+        /// <returns>None</returns>
+        /// <response code="204">Returns if the specialty has been successfully deleted from institution of education.</response>
+        /// <response code="400">If id is not valid.</response>
+        /// <response code="401">If user is unauthorized, token is bad/expired</response>
+        /// <response code="403">If user is not institution of education admin or moderator.</response>
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 401)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 403)]
+        [ProducesResponseType(typeof(DescriptionResponseApiModel), 404)]
+        [ProducesResponseType(typeof(ErrorDetails), 500)]
+        [HttpPatch("InstitutionOfEducation/{specialtyId}")]
+        [Authorize(Roles = "InstitutionOfEducationAdmin,InstitutionOfEducationModerator")]
+        public async Task<IActionResult> DeleteSpecialtyFromInstitutionOfEducation(string specialtyId, string institutionOfEducationId)
+        {
+            await _specialtyService.DeleteSpecialtyFromInstitutionOfEducation(specialtyId, institutionOfEducationId);
+            return NoContent();
+        }
     }
 }

--- a/YIF_Backend/YIF_Backend.csproj
+++ b/YIF_Backend/YIF_Backend.csproj
@@ -59,4 +59,6 @@
 
   <Import Project="..\YIF.Shared\YIF.Shared.projitems" Label="Shared" />
 
+  <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+
 </Project>

--- a/YIF_XUnitTests/Integration/YIF_Backend/Controllers/InstitutionOfEducationAdminControllerTests.cs
+++ b/YIF_XUnitTests/Integration/YIF_Backend/Controllers/InstitutionOfEducationAdminControllerTests.cs
@@ -1,0 +1,76 @@
+﻿using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF_XUnitTests.Integration.Fixture;
+using YIF_XUnitTests.Integration.YIF_Backend.Controllers.DataAttribute;
+
+namespace YIF_XUnitTests.Integration.YIF_Backend.Controllers
+{
+    public class InstitutionOfEducationAdminControllerTests:TestServerFixture
+    {
+        private IoEAdminInputAttribute _adminInputAttribute;
+        public InstitutionOfEducationAdminControllerTests(ApiWebApplicationFactory fixture)
+        {
+            _client = getInstance(fixture);
+
+            _client = fixture.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton<IPolicyEvaluator, FakePolicyEvaluator>();
+                });
+            }).CreateClient();
+
+            _adminInputAttribute = new IoEAdminInputAttribute(_context);
+        }
+
+        [Fact]
+        public async Task AddSpecialtyToIoE_ShouldReturnOk()
+        {
+            //Arrange
+            _adminInputAttribute.SetUserIdByIoEAdminUserIdForHttpContext();
+            var chosen = _context.SpecialtyToInstitutionOfEducations.AsNoTracking().FirstOrDefault();
+
+            _context.SpecialtyToInstitutionOfEducations.Remove(chosen);
+            await _context.SaveChangesAsync();
+
+            var model = new SpecialtyToInstitutionOfEducationPostApiModel()
+            {
+                SpecialtyId = chosen.SpecialtyId,
+                InstitutionOfEducationId = chosen.InstitutionOfEducationId
+            };
+
+            // Act            
+            var response = await _client.PostAsync($"/api/InstitutionOfEducationAdmin/AddSpecialtyToInstitutionOfEducation", ContentHelper.GetStringContent(model));
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task DeleteSpecialtyFromIoE_EndpointReturnNoContent()
+        {
+            //Arrange
+            var institutionOfEducation = _context.InstitutionOfEducations.AsNoTracking().FirstOrDefault();
+            var specialty = _context.SpecialtyToInstitutionOfEducations.AsNoTracking().Where(x => x.Id == institutionOfEducation.Id).FirstOrDefault();
+
+            var model = new SpecialtyToInstitutionOfEducationPostApiModel()
+            {
+                SpecialtyId = specialty.SpecialtyId,
+                InstitutionOfEducationId = institutionOfEducation.Id
+            };
+
+            //Act
+            var response = await _client.PatchAsync(
+                $"/api/Specialty/InstitutionOfEducationAdmin/DeleteSpecialtyFromInstitutionOfEducation", ContentHelper.GetStringContent(model));
+
+            //Assert
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/YIF_XUnitTests/Integration/YIF_Backend/Controllers/InstitutionOfEducationModeratorControllerTests.cs
+++ b/YIF_XUnitTests/Integration/YIF_Backend/Controllers/InstitutionOfEducationModeratorControllerTests.cs
@@ -1,0 +1,76 @@
+﻿using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF_XUnitTests.Integration.Fixture;
+using YIF_XUnitTests.Integration.YIF_Backend.Controllers.DataAttribute;
+
+namespace YIF_XUnitTests.Integration.YIF_Backend.Controllers
+{
+    public class InstitutionOfEducationModeratorControllerTests:TestServerFixture
+    {
+        private IoEModeratorInputAttribute _moderatorInputAttribute;
+        public InstitutionOfEducationModeratorControllerTests(ApiWebApplicationFactory fixture)
+        {
+            _client = getInstance(fixture);
+
+            _client = fixture.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton<IPolicyEvaluator, FakePolicyEvaluator>();
+                });
+            }).CreateClient();
+
+            _moderatorInputAttribute = new IoEModeratorInputAttribute(_context);
+        }
+
+        [Fact]
+        public async Task AddSpecialtyToIoE_ShouldReturnOk()
+        {
+            //Arrange
+            _moderatorInputAttribute.SetUserIdByIoEModeratorUserIdForHttpContext();
+            var chosen = _context.SpecialtyToInstitutionOfEducations.AsNoTracking().FirstOrDefault();
+
+            _context.SpecialtyToInstitutionOfEducations.Remove(chosen);
+            await _context.SaveChangesAsync();
+
+            var model = new SpecialtyToInstitutionOfEducationPostApiModel()
+            {
+                SpecialtyId = chosen.SpecialtyId,
+                InstitutionOfEducationId = chosen.InstitutionOfEducationId
+            };
+
+            // Act            
+            var response = await _client.PostAsync($"/api/InstitutionOfEducationModerator/AddSpecialtyToInstitutionOfEducation", ContentHelper.GetStringContent(model));
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Fact]
+        public async Task DeleteSpecialtyFromIoE_EndpointReturnNoContent()
+        {
+            //Arrange
+            var institutionOfEducation = _context.InstitutionOfEducations.AsNoTracking().FirstOrDefault();
+            var specialty = _context.SpecialtyToInstitutionOfEducations.AsNoTracking().Where(x => x.Id == institutionOfEducation.Id).FirstOrDefault();
+
+            var model = new SpecialtyToInstitutionOfEducationPostApiModel()
+            {
+                SpecialtyId = specialty.SpecialtyId,
+                InstitutionOfEducationId = institutionOfEducation.Id
+            };
+
+            //Act
+            var response = await _client.PatchAsync(
+                $"/api/Specialty/InstitutionOfEducationModerator/DeleteSpecialtyFromInstitutionOfEducation", ContentHelper.GetStringContent(model));
+
+            //Assert
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/YIF_XUnitTests/Integration/YIF_Backend/Controllers/SpecialtyControllerTests.cs
+++ b/YIF_XUnitTests/Integration/YIF_Backend/Controllers/SpecialtyControllerTests.cs
@@ -175,5 +175,22 @@ namespace YIF_XUnitTests.Integration.YIF_Backend.Controllers
             response.EnsureSuccessStatusCode();
         }
 
+        [Fact]
+        public async Task DeleteSpecialtyFromInstitutionOfEducation_EndpointReturnNoContent()
+        {
+            //Arrange
+            var institutionOfEducation = _context.InstitutionOfEducations.AsNoTracking().FirstOrDefault();
+            var specialty = _context.SpecialtyToInstitutionOfEducations.AsNoTracking().Where(x => x.Id == institutionOfEducation.Id).FirstOrDefault();
+
+            var model = institutionOfEducation.Id;
+
+            //Act
+            var response = await _client.PatchAsync(
+                $"/api/Specialty/InstitutionOfEducation/{specialty.Id}&institutionOfEducationId={institutionOfEducation.Id}", ContentHelper.GetStringContent(model));
+
+            //Assert
+            response.EnsureSuccessStatusCode();
+        }
+
     }
 }

--- a/YIF_XUnitTests/Unit/YIF.Core.Service/Concrete/Services/IoEAdminServiceTests.cs
+++ b/YIF_XUnitTests/Unit/YIF.Core.Service/Concrete/Services/IoEAdminServiceTests.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Resources;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Linq.Expressions;
+using Moq;
+using SendGrid.Helpers.Errors.Model;
+using Xunit;
+using YIF.Core.Data.Entities;
+using YIF.Core.Data.Interfaces;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.DtoModels.EntityDTO;
+using YIF.Core.Service.Concrete.Services;
+
+namespace YIF_XUnitTests.Unit.YIF.Core.Service.Concrete.Services
+{
+    public class IoEAdminServiceTests
+    {
+        private readonly IoEAdminService _ioEAdminService;
+        private readonly Mock<ISpecialtyRepository<Specialty, SpecialtyDTO>> _specialtyRepository= new Mock<ISpecialtyRepository<Specialty, SpecialtyDTO>>();
+        private readonly Mock<ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO>> 
+            _specialtyToIoERepository = new Mock<ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO>>();
+        private readonly Mock<IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO>> 
+            _ioERepository = new Mock<IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO>>();
+        private readonly Mock<ResourceManager> _resourceManager = new Mock<ResourceManager>();
+        
+        public IoEAdminServiceTests()
+        {
+            _ioEAdminService = new IoEAdminService(
+                _specialtyRepository.Object,
+                _ioERepository.Object,
+                _specialtyToIoERepository.Object,
+                _resourceManager.Object
+            );
+        }
+
+
+        [Fact]
+        public async Task AddSpecialtyToIoE_ShouldAddSpecialty()
+        {
+            //Arrange
+            var specialty = true;
+            var institution = true;
+            var entity = new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                SpecialtyId = "1",
+                InstitutionOfEducationId = "1"
+            };
+            _specialtyRepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(specialty);
+            _ioERepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(institution);
+            _specialtyToIoERepository.Setup(x => x.AddSpecialty(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+            // Act
+            var exception = await Record
+                .ExceptionAsync(() => _ioEAdminService.AddSpecialtyToIoe(entity));
+
+            // Assert
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void AddSpecialtyToIoE_ShouldReturnBadRequestException_IfSpecialtyNotFound()
+        {
+            //Arrange
+            var specialty = false;
+            var institution = true;
+            var entity = new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                SpecialtyId = "1",
+                InstitutionOfEducationId = "1"
+            };
+            _specialtyRepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(specialty);
+            _ioERepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(institution);
+            _specialtyToIoERepository.Setup(x => x.AddSpecialty(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+            // Act
+            Func<Task> act = () => _ioEAdminService.AddSpecialtyToIoe(entity);
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
+        [Fact]
+        public void AddSpecialtyToIoE_ShouldReturnBadRequestException_IfIoENotFound()
+        {
+            //Arrange
+            var specialty = true;
+            var institution = false;
+            var entity = new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                SpecialtyId = "1",
+                InstitutionOfEducationId = "1"
+            };
+            _specialtyRepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(specialty);
+            _ioERepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(institution);
+            _specialtyToIoERepository.Setup(x => x.AddSpecialty(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+            // Act
+            Func<Task> act = () => _ioEAdminService.AddSpecialtyToIoe(entity);
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
+        [Fact]
+        public async Task DeleteSpecialtyFromInstitutionOfEducation_ShouldDeleteSpecialtyFromInstitutionOfEducation_IfEverythingOk()
+        {
+            // Arrange  
+            var specialty = true;
+            var institutionOfEducation = true;
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = "IoEId", SpecialtyId = "SpecialtyId" } };
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            var exception = await Record
+                .ExceptionAsync(() => _ioEAdminService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel { 
+                    InstitutionOfEducationId = "IoEId", 
+                    SpecialtyId = "SpecialtyId" }));
+
+            // Assert
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfInstitutionOfEducationNotFound()
+        {
+            // Arrange  
+            var specialty = true;
+            // InstitutionNotFound
+            var institutionOfEducation = false;
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = "IoEId", SpecialtyId = "SpecialtyId" } };
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _ioEAdminService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                InstitutionOfEducationId = "IoEId",
+                SpecialtyId = "SpecialtyId"
+            });
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfSpecialtyNotFound()
+        {
+            // Arrange  
+            //Specialty not found
+            var specialty = false;
+
+            var institutionOfEducation = true;
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = "IoEId", SpecialtyId = "SpecialtyId" } };
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _ioEAdminService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                InstitutionOfEducationId = "IoEId",
+                SpecialtyId = "SpecialtyId"
+            });
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfSpecialtyInInstitutionOfEducationNotFound()
+        {
+            // Arrange  
+            var specialty = true;
+            var institutionOfEducation = true;
+            //SpecialtyToInstitutionOfEducation not found
+            List<SpecialtyToInstitutionOfEducationDTO> specialtyToIoe = null;
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _ioEAdminService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                InstitutionOfEducationId = "IoEId",
+                SpecialtyId = "SpecialtyId"
+            });
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+    }
+}

--- a/YIF_XUnitTests/Unit/YIF.Core.Service/Concrete/Services/IoEModeratorServiceTests.cs
+++ b/YIF_XUnitTests/Unit/YIF.Core.Service/Concrete/Services/IoEModeratorServiceTests.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Resources;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Moq;
+using SendGrid.Helpers.Errors.Model;
+using Xunit;
+using YIF.Core.Data.Entities;
+using YIF.Core.Data.Interfaces;
+using YIF.Core.Domain.ApiModels.RequestApiModels;
+using YIF.Core.Domain.DtoModels.EntityDTO;
+using YIF.Core.Service.Concrete.Services;
+
+namespace YIF_XUnitTests.Unit.YIF.Core.Service.Concrete.Services
+{
+    public class IoEModeratorServiceTests
+    {
+        private readonly IoEModeratorService _ioEModeratorService;
+        private readonly Mock<ISpecialtyRepository<Specialty, SpecialtyDTO>> _specialtyRepository = new Mock<ISpecialtyRepository<Specialty, SpecialtyDTO>>();
+        private readonly Mock<ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO>>
+            _specialtyToIoERepository = new Mock<ISpecialtyToInstitutionOfEducationRepository<SpecialtyToInstitutionOfEducation, SpecialtyToInstitutionOfEducationDTO>>();
+        private readonly Mock<IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO>>
+            _ioERepository = new Mock<IInstitutionOfEducationRepository<InstitutionOfEducation, InstitutionOfEducationDTO>>();
+        private readonly Mock<ResourceManager> _resourceManager = new Mock<ResourceManager>();
+
+        public IoEModeratorServiceTests()
+        {
+            _ioEModeratorService = new IoEModeratorService(
+                _specialtyRepository.Object,
+                _ioERepository.Object,
+                _specialtyToIoERepository.Object,
+                _resourceManager.Object
+            );
+        }
+
+        [Fact]
+        public async Task AddSpecialtyToIoE_ShouldAddSpecialty()
+        {
+            //Arrange
+            var specialty = true;
+            var institution = true;
+            var entity = new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                SpecialtyId = "1",
+                InstitutionOfEducationId = "1"
+            };
+            _specialtyRepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(specialty);
+            _ioERepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(institution);
+            _specialtyToIoERepository.Setup(x => x.AddSpecialty(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+            // Act
+            var exception = await Record
+                .ExceptionAsync(() => _ioEModeratorService.AddSpecialtyToIoe(entity));
+
+            // Assert
+            Assert.Null(exception);
+        }
+        [Fact]
+        public void AddSpecialtyToIoE_ShouldReturnBadRequestException_IfSpecialtyNotFound()
+        {
+            //Arrange
+            var specialty = false;
+            var institution = true;
+            var entity = new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                SpecialtyId = "1",
+                InstitutionOfEducationId = "1"
+            };
+            _specialtyRepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(specialty);
+            _ioERepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(institution);
+            _specialtyToIoERepository.Setup(x => x.AddSpecialty(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+            // Act
+            Func<Task> act = () => _ioEModeratorService.AddSpecialtyToIoe(entity);
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
+        [Fact]
+        public void AddSpecialtyToIoE_ShouldReturnBadRequestException_IfIoENotFound()
+        {
+            //Arrange
+            var specialty = true;
+            var institution = false;
+            var entity = new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                SpecialtyId = "1",
+                InstitutionOfEducationId = "1"
+            };
+            _specialtyRepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(specialty);
+            _ioERepository.Setup(x => x.ContainsById(It.IsAny<string>())).ReturnsAsync(institution);
+            _specialtyToIoERepository.Setup(x => x.AddSpecialty(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+            // Act
+            Func<Task> act = () => _ioEModeratorService.AddSpecialtyToIoe(entity);
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
+        [Fact]
+        public async Task DeleteSpecialtyFromInstitutionOfEducation_ShouldDeleteSpecialtyFromInstitutionOfEducation_IfEverythingOk()
+        {
+            // Arrange  
+            var specialty = true;
+            var institutionOfEducation = true;
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = "IoEId", SpecialtyId = "SpecialtyId" } };
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            var exception = await Record
+                .ExceptionAsync(() => _ioEModeratorService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel
+                {
+                    InstitutionOfEducationId = "IoEId",
+                    SpecialtyId = "SpecialtyId"
+                }));
+
+            // Assert
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfInstitutionOfEducationNotFound()
+        {
+            // Arrange  
+            var specialty = true;
+            // InstitutionNotFound
+            var institutionOfEducation = false;
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = "IoEId", SpecialtyId = "SpecialtyId" } };
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _ioEModeratorService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                InstitutionOfEducationId = "IoEId",
+                SpecialtyId = "SpecialtyId"
+            });
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfSpecialtyNotFound()
+        {
+            // Arrange  
+            //Specialty not found
+            var specialty = false;
+
+            var institutionOfEducation = true;
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = "IoEId", SpecialtyId = "SpecialtyId" } };
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _ioEModeratorService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                InstitutionOfEducationId = "IoEId",
+                SpecialtyId = "SpecialtyId"
+            });
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfSpecialtyInInstitutionOfEducationNotFound()
+        {
+            // Arrange  
+            var specialty = true;
+            var institutionOfEducation = true;
+            //SpecialtyToInstitutionOfEducation not found
+            List<SpecialtyToInstitutionOfEducationDTO> specialtyToIoe = null;
+
+            _specialtyRepository.
+                Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _ioERepository
+                .Setup(sr => sr.ContainsById(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToIoERepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToIoERepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _ioEModeratorService.DeleteSpecialtyToIoe(new SpecialtyToInstitutionOfEducationPostApiModel
+            {
+                InstitutionOfEducationId = "IoEId",
+                SpecialtyId = "SpecialtyId"
+            });
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+    }
+}

--- a/YIF_XUnitTests/Unit/YIF.Core.Service/Concrete/Services/SpecialtyServiceTests.cs
+++ b/YIF_XUnitTests/Unit/YIF.Core.Service/Concrete/Services/SpecialtyServiceTests.cs
@@ -802,6 +802,129 @@ namespace YIF_XUnitTests.Unit.YIF.Core.Service.Concrete.Services
             Assert.ThrowsAsync<BadRequestException>(act);
         }
 
+        [Fact]
+        public async Task DeleteSpecialtyFromInstitutionOfEducation_ShouldDeleteSpecialtyFromInstitutionOfEducation_IfEverythingOk()
+        {
+            // Arrange  
+            var specialty = GetSpecialties().ToList()[0];
+            var institutionOfEducation = new InstitutionOfEducationDTO { Id = "IoEId" };
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO> 
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = institutionOfEducation.Id, SpecialtyId = specialty.Id } };
+
+            _specialtyRepository.
+                Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _institutionOfEducationRepository
+                .Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToInstitutionOfEducationRepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToInstitutionOfEducationRepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            var exception = await Record
+                .ExceptionAsync(() => _specialtyService.DeleteSpecialtyFromInstitutionOfEducation(specialty.Id, It.IsAny<string>()));
+
+            // Assert
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfInstitutionOfEducationNotFound()
+        {
+            // Arrange  
+            var specialty = GetSpecialties().ToList()[0];
+            // InstitutionNotFound
+            InstitutionOfEducationDTO institutionOfEducation = null;
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = "IoEId", SpecialtyId = specialty.Id } };
+
+            _specialtyRepository.
+                Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _institutionOfEducationRepository
+                .Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToInstitutionOfEducationRepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToInstitutionOfEducationRepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _specialtyService.DeleteSpecialtyFromInstitutionOfEducation(specialty.Id, It.IsAny<string>());
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfSpecialtyNotFound()
+        {
+            // Arrange  
+            //Specialty not found
+            SpecialtyDTO specialty = null;
+
+            var institutionOfEducation = new InstitutionOfEducationDTO { Id = "IoEId" };
+            var specialtyToIoe = new List<SpecialtyToInstitutionOfEducationDTO>
+            { new SpecialtyToInstitutionOfEducationDTO{ Id = "SpecialtyToIoeId", InstitutionOfEducationId = institutionOfEducation.Id, SpecialtyId = "1" } };
+
+            _specialtyRepository.
+                Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _institutionOfEducationRepository
+                .Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToInstitutionOfEducationRepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToInstitutionOfEducationRepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _specialtyService.DeleteSpecialtyFromInstitutionOfEducation(specialty.Id, It.IsAny<string>());
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+        [Fact]
+        public void DeleteSpecialtyFromInstitutionOfEducation_ShouldThrowBadRequestException_IfSpecialtyInInstitutionOfEducationNotFound()
+        {
+            // Arrange  
+            var specialty = GetSpecialties().ToList()[0];
+            var institutionOfEducation = new InstitutionOfEducationDTO { Id = "IoEId" };
+            //SpecialtyToInstitutionOfEducation not found
+            List<SpecialtyToInstitutionOfEducationDTO> specialtyToIoe = null;
+
+            _specialtyRepository.
+                Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(specialty);
+
+            _institutionOfEducationRepository
+                .Setup(sr => sr.Get(It.IsAny<string>()))
+                .ReturnsAsync(institutionOfEducation);
+
+            _specialtyToInstitutionOfEducationRepository
+                .Setup(sr => sr.Find(It.IsAny<Expression<Func<SpecialtyToInstitutionOfEducation, bool>>>()))
+                .ReturnsAsync(specialtyToIoe);
+
+            _specialtyToInstitutionOfEducationRepository.Setup(sr => sr.Update(It.IsAny<SpecialtyToInstitutionOfEducation>()));
+
+            // Act
+            Func<Task> act = () => _specialtyService.DeleteSpecialtyFromInstitutionOfEducation(specialty.Id, It.IsAny<string>());
+
+            // Assert
+            Assert.ThrowsAsync<BadRequestException>(act);
+        }
+
         private SpecialtyToInstitutionOfEducationToGraduate GetFavoriteSpecialtyAndInstitutionOfEducations()
         {
             return new SpecialtyToInstitutionOfEducationToGraduate

--- a/YIF_XUnitTests/Unit/YIF_Backend/Controllers/SpecialtyControllerTests.cs
+++ b/YIF_XUnitTests/Unit/YIF_Backend/Controllers/SpecialtyControllerTests.cs
@@ -195,5 +195,19 @@ namespace YIF_XUnitTests.Unit.YIF_Backend.Controllers
             // Assert
             Assert.IsType<NoContentResult>(result);
         }
+
+        [Fact]
+        public async Task DeleteSpecialtyFromInstitutionOfEducation_EndpointReturnsNoContentResult()
+        {
+            // Arrange
+            _mockContext.SetupGet(hc => hc.User).Returns(_principal);
+            _specialtyService.Setup(x => x.DeleteSpecialtyFromInstitutionOfEducation(It.IsAny<string>(), It.IsAny<string>()));
+
+            // Act
+            var result = await _testControl.DeleteSpecialtyFromInstitutionOfEducation(It.IsAny<string>(), It.IsAny<string>());
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+        }
     }
 }

--- a/YIF_XUnitTests/YIF_XUnitTests.csproj
+++ b/YIF_XUnitTests/YIF_XUnitTests.csproj
@@ -41,6 +41,7 @@
     <Folder Include="Integration\YIF.Core.Service\Mapping\" />
     <Folder Include="Unit\YIF.Core.Data\" />
     <Folder Include="Unit\YIF.Core.Service\Mapping\" />
+    <Folder Include="Unit\YIF_Backend\Controllers\Новая папка\" />
   </ItemGroup>
 
   <Import Project="..\YIF.Shared\YIF.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
## ClickUp

* [Main ClickUp ticket](https://app.clickup.com/t/g31k7p)


## Code reviewers

- [ ] @ProfesorProst 
- [ ] @ArturSodolskyi 
- [ ] @IvanBorovets 

### Second Level Review

- [ ] @katemalash 

## Summary of issue

Add delete specialty endpoint for institution of education admin/moderator

## Summary of change

Delete specialty endpoint for institution of education admin/moderator was added. It should be soft delete, to be able to restore information later. So I added column IsDeleted for SpecialtyToInstitutionOfEducations and updated database seeder. 

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
