### PR TITLE
#146 Added unit tests for IoE Admin/Moderator delete specialty endpoint

### DIFF
--- a/YIF_XUnitTests/Unit/YIF_Backend/Controllers/InstitutionOfEducationAdminControllerTests.cs
+++ b/YIF_XUnitTests/Unit/YIF_Backend/Controllers/InstitutionOfEducationAdminControllerTests.cs
@@ -85,5 +85,18 @@ namespace YIF_XUnitTests.Unit.YIF_Backend.Controllers
             // Assert  
             Assert.IsType<OkObjectResult>(result);
         }
+
+        [Fact]
+        public async void DeleteSpecialtyFromInstitutionOfEducation_ShouldReturnNoContent_IfEverythingIsOk()
+        {
+            // Arrange
+            _ioEAdminService.Setup(x => x.DeleteSpecialtyToIoe(It.IsAny<SpecialtyToInstitutionOfEducationPostApiModel>()));
+
+            // Act
+            var result = await _testControl.DeleteSpecialtyFromIoE(new SpecialtyToInstitutionOfEducationPostApiModel());
+
+            // Assert  
+            Assert.IsType<NoContentResult>(result);
+        }
     }
 }

--- a/YIF_XUnitTests/Unit/YIF_Backend/Controllers/InstitutionOfEducationModeratorControllerTests.cs
+++ b/YIF_XUnitTests/Unit/YIF_Backend/Controllers/InstitutionOfEducationModeratorControllerTests.cs
@@ -62,5 +62,18 @@ namespace YIF_XUnitTests.Unit.YIF_Backend.Controllers
             //Assert
             Assert.IsType<OkObjectResult>(result);
         }
+
+        [Fact]
+        public async void DeleteSpecialtyFromInstitutionOfEducation_ShouldReturnNoContent_IfEverythingIsOk()
+        {
+            // Arrange
+            _ioEModeratorService.Setup(x => x.DeleteSpecialtyToIoe(It.IsAny<SpecialtyToInstitutionOfEducationPostApiModel>()));
+
+            // Act
+            var result = await _testControl.DeleteSpecialtyFromIoE(new SpecialtyToInstitutionOfEducationPostApiModel());
+
+            // Assert  
+            Assert.IsType<NoContentResult>(result);
+        }
     }
 }


### PR DESCRIPTION
## ClickUp

* [Main ClickUp ticket](https://app.clickup.com/t/h514k3)


## Code reviewers

- [ ] @DimaMoroziuk 
- [ ] @stein4444 
- [ ] @yuxima 

### Second Level Review

- [ ] @katemalash 

## Summary of issue

There was no unit tests for DeleteSpecialtyInIoE for IoEAdmin/Moderator method

## Summary of change

I made unit tests for DeleteSpecialtyInIoE for IoEAdmin/Moderator method